### PR TITLE
fix: Path::canonicalize all test workspace paths

### DIFF
--- a/lib/Workspace.php
+++ b/lib/Workspace.php
@@ -18,7 +18,7 @@ class Workspace
 
     public function __construct(string $path)
     {
-        $this->path = $path;
+        $this->path = Path::canonicalize($path);
     }
 
     public static function create(string $path): self


### PR DESCRIPTION
As part of port-to-windows effort, normalize paths used by tests.